### PR TITLE
add allowed parameter to Wrap

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,5 +54,4 @@ if err := topOfCalls(); err != nil {
 
 ## Future improvements
 
-* Wrapping only specific errors. Currently `With` masks underlying wraps and `Wrap` lets them all through.
 * Garbage reduction. Currently we maintain pointer equality in the same vein as `errors.New` as developers likely expect, however it requires heap allocation. This only shows up however in very fast loops.

--- a/errutil.go
+++ b/errutil.go
@@ -1,6 +1,7 @@
 package errutil
 
 import (
+	"errors"
 	"fmt"
 	"net/url"
 	"path"
@@ -63,17 +64,31 @@ type Tags map[string]any
 
 // Wrap enriches err with stack information from the caller of Wrap.
 // The returned error will implement Unwrap (used by errors.Is/As)
-// returning err.
+// returning err if allowed is empty, or if an item in allowed matches
+// err using errors.Is.
 //
 // Generally, Wrap should only be used when the returned error is
-// expected to be used with errors.Is or similar.
-func Wrap(err error) error {
-	return NewFrameError(Caller(1), nil, err, true)
+// expected to be used with errors.Is or similar. Non-sentinel
+// errors can implement errors.Is to be used with allowed.
+func Wrap(err error, allowed ...error) error {
+	return wrap(err, nil, allowed...)
 }
 
 // Wrapt is like Wrap but adds tags t to the error information.
-func Wrapt(err error, t Tags) error {
-	return NewFrameError(Caller(1), t, err, true)
+func Wrapt(err error, t Tags, allowed ...error) error {
+	return wrap(err, t, allowed...)
+}
+
+func wrap(err error, t Tags, allowed ...error) error {
+	if len(allowed) == 0 {
+		return NewFrameError(Caller(2), t, err, true)
+	}
+	for _, a := range allowed {
+		if errors.Is(err, a) {
+			return NewFrameError(Caller(2), t, err, true)
+		}
+	}
+	return NewFrameError(Caller(2), t, err, false)
 }
 
 // With enriches err with stack information from the caller of With.

--- a/errutil_test.go
+++ b/errutil_test.go
@@ -112,13 +112,13 @@ errutil/test/dot.pkg dot.pkg.go:26 StdlibWitht
 errutil/test/dot.pkg dot.pkg.go:26 StdlibWitht
 	msg=regular`,
 		},
-		"AnonymousFunc": {
+		"AnonymousFunc": { // ends up inlining the dot.pkg.AnonymousFunc frame.
 			dotpkg.AnonymousFunc(),
 			errutil.Stack{
-				{Pkg: "errutil/test/dot.pkg", Func: "AnonymousFunc.func1.1", File: "dot.pkg.go", Line: 33, Values: errutil.Tags{"k1": true}},
+				{Pkg: "errutil_test", Func: "TestBuildStack.AnonymousFunc.func2.1", File: "dot.pkg.go", Line: 33, Values: errutil.Tags{"k1": true}},
 			},
 			`
-errutil/test/dot.pkg dot.pkg.go:33 AnonymousFunc.func1.1
+errutil_test dot.pkg.go:33 TestBuildStack.AnonymousFunc.func2.1
 	k1=true`,
 		},
 		"AnonymousValue": {
@@ -176,9 +176,11 @@ func TestIs_wrapped(t *testing.T) {
 	target := errutil.New(errutil.Tags{"some": "tag"})
 
 	errs := map[string]error{
-		"wrap":        errutil.Wrap(target),
-		"wrap tags":   errutil.Wrapt(target, errutil.Tags{"some": "tag"}),
-		"double wrap": errutil.Wrap(errutil.Wrap(target)),
+		"wrap":              errutil.Wrap(target),
+		"wrap allowed":      errutil.Wrap(target, target),
+		"wrap tags":         errutil.Wrapt(target, errutil.Tags{"some": "tag"}),
+		"wrap tags allowed": errutil.Wrapt(target, errutil.Tags{"some": "tag"}, target),
+		"double wrap":       errutil.Wrap(errutil.Wrap(target)),
 	}
 
 	for n, err := range errs {
@@ -187,6 +189,11 @@ func TestIs_wrapped(t *testing.T) {
 				t.Fatal("expected true")
 			}
 		})
+	}
+
+	err := errutil.Wrap(target, errors.New("not allowed"))
+	if errors.Is(err, target) {
+		t.Fatal("should not be allowed")
 	}
 }
 


### PR DESCRIPTION
Allows limiting which errors will be able to pass through and be Unwraped later, making stronger/clearer function contracts.