### PR TITLE
tools: prove nil checks through predicates, merges, sentinels

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,8 @@ if err := f(); err != nil {
 return nil
 ```
 
+Besides `err != nil` guards, recognized nil checks include equality against a sentinel, `errors.Is`/`errors.As`/`errors.AsType` conditions, comma-ok type assertions, `ctx.Err()` after `<-ctx.Done()`, and bool helper predicates that provably return true only for a non-nil error — through an early `if err == nil { return false }` guard, a merged condition like `return ok && apiErr.Code == code`, or `errors.Is` against a never-nil sentinel var (assigned only non-nil values at initialization, address never escaping).
+
 Suppress with `//errutil:unchecked` on any line of the call (including later lines of a multiline call), the line above it, on the function, or before the `package` declaration (file-wide).
 
 ### Install

--- a/tools/errunchecked/errunchecked.go
+++ b/tools/errunchecked/errunchecked.go
@@ -23,7 +23,7 @@ func Analyzer() *analysis.Analyzer {
 		Name:      "errunchecked",
 		Doc:       "check that errutil.With/Wrap is not called directly on function results without nil check",
 		Requires:  []*analysis.Analyzer{buildssa.Analyzer},
-		FactTypes: []analysis.Fact{(*nonNilError)(nil)},
+		FactTypes: []analysis.Fact{(*nonNilError)(nil), (*nonNilWhenTrue)(nil), (*nonNilVar)(nil)},
 		Run:       run,
 	}
 }
@@ -35,14 +35,24 @@ func run(pass *analysis.Pass) (any, error) {
 	}
 	directives := shared.CollectDirectives(pass, directivePrefix)
 
-	c := &checker{pass: pass, memo: map[funcResult]bool{}, inProgress: map[funcResult]bool{}}
+	c := &checker{
+		pass:           pass,
+		ssaPkg:         ssaInfo.Pkg,
+		srcFuncs:       ssaInfo.SrcFuncs,
+		memo:           map[funcResult]bool{},
+		inProgress:     map[funcResult]bool{},
+		predMemo:       map[funcResult]bool{},
+		predInProgress: map[funcResult]bool{},
+	}
 
-	// Export "always returns non-nil error" facts for this package's functions so
-	// that importing packages can recognize them (cross-package callees have no SSA
-	// body to inspect). This also warms the memo for the check phase below.
-	// Generated functions still export facts — they can vouch for handwritten
-	// callers — but are not checked below.
-	shared.WalkFunctions(ssaInfo.Pkg, ssaInfo.SrcFuncs, c.exportNonNilFact)
+	// Export facts for this package's functions so that importing packages can
+	// recognize them (cross-package callees have no SSA body to inspect):
+	// "always returns non-nil error" and "returns true only when its error
+	// parameter is non-nil". This also warms the memos for the check phase
+	// below. Generated functions still export facts — they can vouch for
+	// handwritten callers — but are not checked below.
+	shared.WalkFunctions(ssaInfo.Pkg, ssaInfo.SrcFuncs, c.exportFacts)
+	c.exportVarFacts()
 
 	generated := shared.GeneratedFiles(pass)
 	shared.WalkFunctions(ssaInfo.Pkg, ssaInfo.SrcFuncs, func(fn *ssa.Function) {
@@ -56,12 +66,21 @@ func run(pass *analysis.Pass) (any, error) {
 	return nil, nil
 }
 
-// checker holds per-package state for the analysis: the pass, plus a memo and
-// in-progress set for the (potentially recursive) non-nil-return computation.
+// checker holds per-package state for the analysis: the pass and its SSA, plus
+// memos and in-progress sets for the (potentially recursive) non-nil-return
+// and true-implies-non-nil computations, and the lazily built never-nil
+// sentinel var verdicts.
 type checker struct {
-	pass       *analysis.Pass
-	memo       map[funcResult]bool
-	inProgress map[funcResult]bool
+	pass           *analysis.Pass
+	ssaPkg         *ssa.Package
+	srcFuncs       []*ssa.Function
+	memo           map[funcResult]bool
+	inProgress     map[funcResult]bool
+	predMemo       map[funcResult]bool
+	predInProgress map[funcResult]bool
+
+	sentinels         map[*ssa.Global]bool // nil until built by localSentinels
+	sentinelsBuilding bool
 }
 
 // nonNilError is a fact attached to a function whose error result at each listed
@@ -74,6 +93,30 @@ type nonNilError struct {
 func (*nonNilError) AFact() {}
 
 func (f *nonNilError) String() string { return fmt.Sprintf("nonNilError%v", f.Indices) }
+
+// nonNilWhenTrue is a fact attached to a bool-returning function that returns
+// true only when its error parameter at each listed index is non-nil. It lets
+// importing packages treat a dominating `if helper(err)` true branch as a nil
+// check on err. Indices are in ssa argument order, so a method's receiver is
+// index 0.
+type nonNilWhenTrue struct {
+	Params []int
+}
+
+func (*nonNilWhenTrue) AFact() {}
+
+func (f *nonNilWhenTrue) String() string { return fmt.Sprintf("nonNilWhenTrue%v", f.Params) }
+
+// nonNilVar is a fact attached to a package-level error var that is a never-nil
+// sentinel: assigned at initialization, every store provably non-nil, and its
+// address never escaping its package. An importer may still legally reassign
+// an exported var, which the home package cannot see; sentinel reassignment is
+// treated as adversarial and ignored.
+type nonNilVar struct{}
+
+func (*nonNilVar) AFact() {}
+
+func (*nonNilVar) String() string { return "nonNilVar" }
 
 type funcResult struct {
 	fn  *ssa.Function
@@ -133,16 +176,17 @@ func (c *checker) isDirectWrapCall(call ssa.CallInstruction) bool {
 // conversions are looked through: a proof on any value in the chain suffices.
 func (c *checker) provedNonNil(v ssa.Value, block *ssa.BasicBlock) bool {
 	for ; v != nil; v = conversionSource(v) {
-		if c.valueNonNil(v) || isNilChecked(v, block) {
+		if c.valueNonNil(v) || c.isNilChecked(v, block, true) {
 			return true
 		}
 	}
 	return false
 }
 
-// exportNonNilFact computes and exports a nonNilError fact for fn, if any of its
-// error results are always non-nil.
-func (c *checker) exportNonNilFact(fn *ssa.Function) {
+// exportFacts computes and exports facts for fn: nonNilError for error results
+// that are always non-nil, and nonNilWhenTrue for bool predicates whose true
+// result implies an error parameter is non-nil.
+func (c *checker) exportFacts(fn *ssa.Function) {
 	obj := fn.Object()
 	// Only exported functions and methods of this package can be referenced (and
 	// have their fact imported) by another package; same-package callees are
@@ -157,6 +201,7 @@ func (c *checker) exportNonNilFact(fn *ssa.Function) {
 	if !ok {
 		return
 	}
+
 	var indices []int
 	for _, i := range shared.ErrorResultIndices(sig) {
 		if c.funcResultNonNil(fn, i) {
@@ -166,11 +211,34 @@ func (c *checker) exportNonNilFact(fn *ssa.Function) {
 	if len(indices) > 0 {
 		c.pass.ExportObjectFact(obj, &nonNilError{Indices: indices})
 	}
+
+	var params []int
+	for i := range fn.Params {
+		if c.trueImpliesNonNil(fn, i) {
+			params = append(params, i)
+		}
+	}
+	if len(params) > 0 {
+		c.pass.ExportObjectFact(obj, &nonNilWhenTrue{Params: params})
+	}
+}
+
+// exportVarFacts exports a nonNilVar fact for each of this package's exported
+// never-nil sentinel vars, so importing packages can prove against them.
+func (c *checker) exportVarFacts() {
+	for g, nonNil := range c.localSentinels() {
+		obj := g.Object()
+		if !nonNil || obj == nil || obj.Pkg() != c.pass.Pkg || !obj.Exported() {
+			continue
+		}
+		c.pass.ExportObjectFact(obj, &nonNilVar{})
+	}
 }
 
 // valueNonNil reports whether v is a provably non-nil error: an interface
 // construction (which is never nil, even when boxing a nil pointer), a known
-// non-nil constructor, or a call whose callee always returns a non-nil error.
+// non-nil constructor, a call whose callee always returns a non-nil error, or
+// a load of a never-nil sentinel var.
 func (c *checker) valueNonNil(v ssa.Value) bool {
 	if src := conversionSource(v); src != nil {
 		return c.valueNonNil(src)
@@ -187,8 +255,105 @@ func (c *checker) valueNonNil(v ssa.Value) bool {
 		if call, ok := val.Tuple.(*ssa.Call); ok {
 			return c.calleeResultNonNil(call.Call.StaticCallee(), val.Index)
 		}
+	case *ssa.UnOp:
+		if val.Op == token.MUL {
+			if g, ok := val.X.(*ssa.Global); ok {
+				return c.globalNonNil(g)
+			}
+		}
 	}
 	return false
+}
+
+// globalNonNil reports whether g is a never-nil sentinel var. For this
+// package's globals it scans the package; for imported ones it consults a
+// nonNilVar fact.
+func (c *checker) globalNonNil(g *ssa.Global) bool {
+	if g.Pkg == c.ssaPkg {
+		return c.localSentinels()[g]
+	}
+	obj := g.Object()
+	if obj == nil {
+		return false
+	}
+	var fact nonNilVar
+	return c.pass.ImportObjectFact(obj, &fact)
+}
+
+// localSentinels computes never-nil verdicts for this package's error vars,
+// once: a single pass classifies every appearance of a global as a load
+// (benign), a store (the value must prove non-nil), or anything else (the
+// address escapes and stores can no longer be tracked). A sentinel must also
+// be stored in the package initializer, or it would be nil before its first
+// assignment. While building, re-entrant queries (a store whose value depends
+// on another global) resolve to false, conservatively but deterministically.
+func (c *checker) localSentinels() map[*ssa.Global]bool {
+	if c.sentinels != nil || c.sentinelsBuilding {
+		return c.sentinels
+	}
+	c.sentinelsBuilding = true
+	defer func() { c.sentinelsBuilding = false }()
+
+	stores := map[*ssa.Global][]ssa.Value{}
+	initStored := map[*ssa.Global]bool{}
+	escaped := map[*ssa.Global]bool{}
+	initFn := c.ssaPkg.Func("init")
+	shared.WalkFunctions(c.ssaPkg, c.srcFuncs, func(fn *ssa.Function) {
+		for _, b := range fn.Blocks {
+			for _, instr := range b.Instrs {
+				switch in := instr.(type) {
+				case *ssa.UnOp:
+					if in.Op == token.MUL {
+						if _, ok := in.X.(*ssa.Global); ok {
+							continue // a plain load
+						}
+					}
+				case *ssa.Store:
+					if g, ok := in.Addr.(*ssa.Global); ok {
+						stores[g] = append(stores[g], in.Val)
+						if fn == initFn {
+							initStored[g] = true
+						}
+						// The stored value may itself be a global's address.
+						if vg, ok := in.Val.(*ssa.Global); ok {
+							escaped[vg] = true
+						}
+						continue
+					}
+				}
+				for _, op := range instr.Operands(nil) {
+					if g, ok := (*op).(*ssa.Global); ok {
+						escaped[g] = true
+					}
+				}
+			}
+		}
+	})
+
+	verdicts := map[*ssa.Global]bool{}
+	for _, mem := range c.ssaPkg.Members {
+		g, ok := mem.(*ssa.Global)
+		if !ok || !isErrorVar(g) || escaped[g] || !initStored[g] {
+			continue
+		}
+		nonNil := true
+		for _, val := range stores[g] {
+			if !c.valueNonNil(val) {
+				nonNil = false
+				break
+			}
+		}
+		verdicts[g] = nonNil
+	}
+	c.sentinels = verdicts
+	return c.sentinels
+}
+
+// isErrorVar reports whether g is a package-level error variable (a Global's
+// type is a pointer to the var's type).
+func isErrorVar(g *ssa.Global) bool {
+	ptr, ok := g.Type().(*types.Pointer)
+	return ok && shared.IsErrorType(ptr.Elem())
 }
 
 // calleeResultNonNil reports whether callee's result at idx is always a non-nil
@@ -216,17 +381,25 @@ func (c *checker) funcResultNonNil(fn *ssa.Function, idx int) bool {
 	if len(fn.Blocks) == 0 {
 		return false
 	}
-	key := funcResult{fn, idx}
-	if v, ok := c.memo[key]; ok {
+	return memoized(c.memo, c.inProgress, funcResult{fn, idx}, func() bool {
+		return c.computeResultNonNil(fn, idx)
+	})
+}
+
+// memoized returns the cached result for key, running compute on a miss.
+// Recursion is treated conservatively: a key already being computed yields
+// false without caching, so the final verdict is still computed and stored.
+func memoized(memo, inProgress map[funcResult]bool, key funcResult, compute func() bool) bool {
+	if v, ok := memo[key]; ok {
 		return v
 	}
-	if c.inProgress[key] {
+	if inProgress[key] {
 		return false
 	}
-	c.inProgress[key] = true
-	res := c.computeResultNonNil(fn, idx)
-	delete(c.inProgress, key)
-	c.memo[key] = res
+	inProgress[key] = true
+	res := compute()
+	delete(inProgress, key)
+	memo[key] = res
 	return res
 }
 
@@ -250,6 +423,179 @@ func (c *checker) computeResultNonNil(fn *ssa.Function, idx int) bool {
 		}
 	}
 	return sawReturn
+}
+
+// trueImpliesNonNil reports whether fn returning true implies its parameter at
+// idx (an error) was non-nil — the `isFooErr(err)` predicate-helper shape —
+// memoized across the package. Recursion is treated conservatively (a cycle
+// yields false), as is a function with no body. idx is in ssa parameter order,
+// so a method's receiver is index 0.
+func (c *checker) trueImpliesNonNil(fn *ssa.Function, idx int) bool {
+	if len(fn.Blocks) == 0 || !isBoolPredicate(fn) ||
+		idx >= len(fn.Params) || !shared.IsErrorType(fn.Params[idx].Type()) {
+		return false
+	}
+	return memoized(c.predMemo, c.predInProgress, funcResult{fn, idx}, func() bool {
+		return c.computeTrueImpliesNonNil(fn, idx)
+	})
+}
+
+// computeTrueImpliesNonNil proves the implication per return: a return is safe
+// when it is dominated by a check establishing the parameter non-nil (any true
+// it returns is covered by the check), or when the returned value itself can
+// only be true with the parameter non-nil (valueImpliesNonNil, covering merged
+// conditions like `return err != nil && ok`).
+func (c *checker) computeTrueImpliesNonNil(fn *ssa.Function, idx int) bool {
+	param := fn.Params[idx]
+	sawReturn := false
+	for _, b := range fn.Blocks {
+		if len(b.Instrs) == 0 {
+			continue
+		}
+		ret, ok := b.Instrs[len(b.Instrs)-1].(*ssa.Return)
+		if !ok {
+			continue
+		}
+		sawReturn = true
+		if len(ret.Results) != 1 {
+			return false
+		}
+		if c.isNilChecked(param, b, false) {
+			continue
+		}
+		if !c.valueImpliesNonNil(ret.Results[0], param, true, map[*ssa.Phi]bool{}) {
+			return false
+		}
+	}
+	return sawReturn
+}
+
+// valueImpliesNonNil reports whether v evaluating to want implies param was
+// non-nil — the value-level counterpart of condEstablishesNonNil, for
+// predicates whose result is a merged condition rather than a branch to
+// distinct returns. A bool constant satisfies any judgment its value cannot
+// trigger; a recognized condition shape satisfies its polarity; negation
+// flips want; and a phi holds when every incoming value either satisfies the
+// judgment or arrives only while param was known non-nil — via a dominating
+// check on the predecessor, or via the edge itself when the predecessor
+// branches directly into the merge (the short-circuit shape: in
+// `return err != nil && ok` the unguarded incoming is constant false, and the
+// guarded one arrives from the non-nil branch).
+//
+// Phi cycles are handled inductively over loop iterations: while a phi's
+// obligations are being checked it is assumed to satisfy them (assumed maps
+// the phi to its want), so a loop accumulator like `res = res || err != nil`
+// discharges its res-was-already-true edge by the induction hypothesis. The
+// hypothesis stands only if every base edge proves out; any failure discards
+// the whole proof.
+func (c *checker) valueImpliesNonNil(v ssa.Value, param ssa.Value, want bool, assumed map[*ssa.Phi]bool) bool {
+	if cnst, ok := v.(*ssa.Const); ok {
+		return isBoolConst(cnst, !want)
+	}
+	if onTrue, ok := c.condImpliesNonNil(v, param, false); ok && onTrue == want {
+		return true
+	}
+	// condImpliesNonNil only negates recognized conditions; recursing here
+	// also covers negation over phis and constants.
+	if un, ok := v.(*ssa.UnOp); ok && un.Op == token.NOT {
+		return c.valueImpliesNonNil(un.X, param, !want, assumed)
+	}
+	phi, ok := v.(*ssa.Phi)
+	if !ok {
+		return false
+	}
+	if w, ok := assumed[phi]; ok {
+		return w == want // the induction hypothesis; a flipped want proves nothing
+	}
+	assumed[phi] = want
+	defer delete(assumed, phi)
+	for i, edge := range phi.Edges {
+		pred := phi.Block().Preds[i]
+		if c.isNilChecked(param, pred, false) || c.edgeEstablishes(pred, phi.Block(), param, assumed) {
+			continue
+		}
+		if !c.valueImpliesNonNil(edge, param, want, assumed) {
+			return false
+		}
+	}
+	return true
+}
+
+// edgeEstablishes reports whether traversing the CFG edge pred→succ implies
+// param was non-nil: pred must end in an If with exactly one successor equal
+// to succ, fixing the condition's truth value on the edge, and that truth
+// value must imply non-nil — directly, or through the induction hypothesis of
+// an assumed phi. This is the φ-incoming-edge counterpart of establishes,
+// which needs a dominated block and cannot see facts that exist only on the
+// edge into a merge (the short-circuit and loop-accumulator shapes).
+func (c *checker) edgeEstablishes(pred, succ *ssa.BasicBlock, param ssa.Value, assumed map[*ssa.Phi]bool) bool {
+	if len(pred.Instrs) == 0 {
+		return false
+	}
+	ifInstr, ok := pred.Instrs[len(pred.Instrs)-1].(*ssa.If)
+	if !ok || pred.Succs[0] == pred.Succs[1] {
+		return false
+	}
+	var condIs bool // the condition's value on this edge
+	switch succ {
+	case pred.Succs[0]:
+		condIs = true
+	case pred.Succs[1]:
+		condIs = false
+	default:
+		return false
+	}
+	cond := ifInstr.Cond
+	for {
+		un, ok := cond.(*ssa.UnOp)
+		if !ok || un.Op != token.NOT {
+			break
+		}
+		cond, condIs = un.X, !condIs
+	}
+	if onTrue, ok := c.condImpliesNonNil(cond, param, false); ok && onTrue == condIs {
+		return true
+	}
+	if phi, ok := cond.(*ssa.Phi); ok {
+		if w, ok := assumed[phi]; ok && w == condIs {
+			return true
+		}
+	}
+	return false
+}
+
+// calleeTrueImpliesNonNil reports whether callee returning true implies its
+// parameter at idx was non-nil. For callees with a body (this package) it
+// inspects the returns; for callees without one (another package) it consults
+// an imported fact.
+func (c *checker) calleeTrueImpliesNonNil(callee *ssa.Function, idx int) bool {
+	if callee == nil {
+		return false
+	}
+	if len(callee.Blocks) > 0 {
+		return c.trueImpliesNonNil(callee, idx)
+	}
+	obj := callee.Object()
+	if obj == nil {
+		return false
+	}
+	var fact nonNilWhenTrue
+	return c.pass.ImportObjectFact(obj, &fact) && slices.Contains(fact.Params, idx)
+}
+
+// isBoolPredicate reports whether fn has exactly one result, of boolean type.
+func isBoolPredicate(fn *ssa.Function) bool {
+	results := fn.Signature.Results()
+	if results.Len() != 1 {
+		return false
+	}
+	basic, ok := results.At(0).Type().Underlying().(*types.Basic)
+	return ok && basic.Info()&types.IsBoolean != 0
+}
+
+func isBoolConst(v ssa.Value, b bool) bool {
+	c, ok := v.(*ssa.Const)
+	return ok && c.Value != nil && c.Value.Kind() == constant.Bool && constant.BoolVal(c.Value) == b
 }
 
 // isContextErrInDoneBranch reports whether call is ctx.Err() and some block that
@@ -431,9 +777,10 @@ func nilCheckEquivalent(a, b ssa.Value) bool {
 
 // isNilChecked reports whether v is guaranteed non-nil at block. This holds when
 // a conditional that establishes v's nil-ness (a v != nil / v == nil test, an
-// equality against a sentinel, errors.Is/As on v, or a comma-ok type assertion
-// on v) guards block via establishes.
-func isNilChecked(v ssa.Value, block *ssa.BasicBlock) bool {
+// equality against a sentinel, errors.Is/As/AsType on v, a predicate helper
+// whose true result implies v is non-nil, or a comma-ok type assertion on v)
+// guards block via establishes. trustSentinels is described on condImpliesNonNil.
+func (c *checker) isNilChecked(v ssa.Value, block *ssa.BasicBlock, trustSentinels bool) bool {
 	for _, b := range block.Parent().Blocks {
 		if len(b.Instrs) == 0 {
 			continue
@@ -442,52 +789,113 @@ func isNilChecked(v ssa.Value, block *ssa.BasicBlock) bool {
 		if !ok {
 			continue
 		}
-		trueBlock, falseBlock := b.Succs[0], b.Succs[1]
-
-		switch cond := ifInstr.Cond.(type) {
-		case *ssa.Call:
-			if isErrorsIsOrAs(cond, v) && establishes(trueBlock, block) {
-				return true
-			}
-		case *ssa.Extract:
-			// The ok of a comma-ok type assertion on v: a nil interface never
-			// asserts successfully to any type, so ok being true implies v is
-			// non-nil. This also covers the if-chain a type switch lowers to
-			// (its `case nil` arm lowers to a nil comparison, handled below).
-			ta, isAssert := cond.Tuple.(*ssa.TypeAssert)
-			if isAssert && cond.Index == 1 && ta.CommaOk && nilCheckEquivalent(ta.X, v) && establishes(trueBlock, block) {
-				return true
-			}
-		case *ssa.BinOp:
-			if cond.Op != token.EQL && cond.Op != token.NEQ {
-				continue
-			}
-			var other ssa.Value
-			switch {
-			case nilCheckEquivalent(cond.X, v):
-				other = cond.Y
-			case nilCheckEquivalent(cond.Y, v):
-				other = cond.X
-			default:
-				continue
-			}
-			equalBlock, notEqualBlock := trueBlock, falseBlock
-			if cond.Op == token.NEQ {
-				equalBlock, notEqualBlock = falseBlock, trueBlock
-			}
-			// v != nil establishes non-nil on the not-equal branch. v == sentinel
-			// establishes it on the equal branch (a nil sentinel is treated as a
-			// deliberate check too; that case is rare and indistinguishable statically).
-			nonNilBlock := equalBlock
-			if isNilConst(other) {
-				nonNilBlock = notEqualBlock
-			}
-			if establishes(nonNilBlock, block) {
-				return true
-			}
+		if c.condEstablishesNonNil(ifInstr.Cond, v, b.Succs[0], b.Succs[1], block, trustSentinels) {
+			return true
 		}
 	}
 	return false
+}
+
+// condEstablishesNonNil reports whether the branch condition cond, with the
+// given true/false successors, establishes that v is non-nil at block.
+func (c *checker) condEstablishesNonNil(cond, v ssa.Value, trueBlock, falseBlock, block *ssa.BasicBlock, trustSentinels bool) bool {
+	onTrue, ok := c.condImpliesNonNil(cond, v, trustSentinels)
+	if !ok {
+		return false
+	}
+	branch := trueBlock
+	if !onTrue {
+		branch = falseBlock
+	}
+	return establishes(branch, block)
+}
+
+// condImpliesNonNil reports whether cond is a recognized nil-ness condition on
+// v, and if so which truth value of cond implies v is non-nil: onTrue is true
+// for conditions like v != nil whose true result implies it, false for ones
+// like v == nil whose false result does. trustSentinels admits comparands and
+// errors.Is targets that are not provably non-nil as deliberate sentinel
+// checks; that reading is only justified in branch position (an `if` written
+// against a sentinel), never when deriving facts from returned values.
+func (c *checker) condImpliesNonNil(cond, v ssa.Value, trustSentinels bool) (onTrue, ok bool) {
+	switch cond := cond.(type) {
+	case *ssa.Call:
+		if isErrorsIsOrAs(cond, v) {
+			// errors.As and errors.AsType are false outright for a nil error,
+			// so only errors.Is needs target scrutiny: Is(nil, nil) is true.
+			target, isIs := errorsIsTarget(cond)
+			if isIs && !c.sentinelTrusted(target, trustSentinels) {
+				return false, false
+			}
+			return true, true
+		}
+		if c.isNonNilPredicateCall(cond, v) {
+			return true, true
+		}
+	case *ssa.Extract:
+		// The ok of a comma-ok type assertion on v: a nil interface never
+		// asserts successfully to any type, so ok being true implies v is
+		// non-nil. This also covers the if-chain a type switch lowers to
+		// (its `case nil` arm lowers to a nil comparison, handled below).
+		ta, isAssert := cond.Tuple.(*ssa.TypeAssert)
+		if isAssert && cond.Index == 1 && ta.CommaOk && nilCheckEquivalent(ta.X, v) {
+			return true, true
+		}
+		// The ok of errors.AsType[T](v): the generic equivalent of
+		// errors.As above — a nil error matches no target type, so ok
+		// being true implies v is non-nil.
+		if call, isCall := cond.Tuple.(*ssa.Call); isCall && cond.Index == 1 && isErrorsAsType(call, v) {
+			return true, true
+		}
+	case *ssa.UnOp:
+		if cond.Op == token.NOT {
+			onTrue, ok = c.condImpliesNonNil(cond.X, v, trustSentinels)
+			return !onTrue, ok
+		}
+	case *ssa.BinOp:
+		return c.compareImpliesNonNil(cond, v, trustSentinels)
+	}
+	return false, false
+}
+
+// compareImpliesNonNil is the comparison case of condImpliesNonNil: an
+// equality or inequality of v against nil or a sentinel.
+func (c *checker) compareImpliesNonNil(cond *ssa.BinOp, v ssa.Value, trustSentinels bool) (onTrue, ok bool) {
+	if cond.Op != token.EQL && cond.Op != token.NEQ {
+		return false, false
+	}
+	var other ssa.Value
+	switch {
+	case nilCheckEquivalent(cond.X, v):
+		other = cond.Y
+	case nilCheckEquivalent(cond.Y, v):
+		other = cond.X
+	default:
+		return false, false
+	}
+	otherIsNil := isNilConst(other)
+	if !otherIsNil && !c.sentinelTrusted(other, trustSentinels) {
+		return false, false
+	}
+	// v == sentinel implies non-nil when true; v == nil implies it when
+	// false. NEQ flips both.
+	onTrue = !otherIsNil
+	if cond.Op == token.NEQ {
+		onTrue = !onTrue
+	}
+	return onTrue, true
+}
+
+// sentinelTrusted reports whether x can stand as the non-nil side of a
+// sentinel check: trusted outright in branch position (an `if` deliberately
+// written against a sentinel), otherwise it must be provably non-nil — a
+// constructed value, a never-nil sentinel var, or a callee with a fact — not,
+// say, a forwarded parameter of the enclosing predicate. Trusting unproven
+// values outside branch position would, for example, derive a predicate fact
+// from the `return err == target` inside errors.Is itself, which is true for
+// a nil err and nil target.
+func (c *checker) sentinelTrusted(x ssa.Value, trustSentinels bool) bool {
+	return trustSentinels || c.valueNonNil(x)
 }
 
 // establishes reports whether a property that holds on branch is guaranteed to
@@ -495,6 +903,53 @@ func isNilChecked(v ssa.Value, block *ssa.BasicBlock) bool {
 // predecessor so it is entered only via its conditional edge (see isNilChecked).
 func establishes(branch, block *ssa.BasicBlock) bool {
 	return len(branch.Preds) == 1 && branch.Dominates(block)
+}
+
+// isNonNilPredicateCall reports whether call is a bool predicate — the
+// `isFooErr(err)` helper shape — whose true result implies v, passed as one of
+// its arguments, is non-nil. Static calls only: the arguments align with the
+// callee's parameters (a method's receiver is argument 0 of both).
+func (c *checker) isNonNilPredicateCall(call *ssa.Call, v ssa.Value) bool {
+	callee := call.Call.StaticCallee()
+	for i, arg := range call.Call.Args {
+		if nilCheckEquivalent(arg, v) && c.calleeTrueImpliesNonNil(callee, i) {
+			return true
+		}
+	}
+	return false
+}
+
+// errorsIsTarget returns the target argument of an errors.Is call; ok is false
+// for any other call.
+func errorsIsTarget(call *ssa.Call) (target ssa.Value, ok bool) {
+	pkg, name, ok := shared.CalleeInfo(call)
+	if !ok || pkg != "errors" || name != "Is" {
+		return nil, false
+	}
+	args := call.Call.Args
+	if len(args) < 2 {
+		return nil, false
+	}
+	return args[1], true
+}
+
+// isErrorsAsType checks if the call is errors.AsType[T](v). Like errors.As, a
+// true ok result implies v is non-nil, since a nil error matches no target
+// type. The callee resolves through Origin because the builder may present
+// the call as a generic instantiation.
+func isErrorsAsType(call *ssa.Call, v ssa.Value) bool {
+	callee := call.Call.StaticCallee()
+	if callee == nil {
+		return false
+	}
+	if origin := callee.Origin(); origin != nil {
+		callee = origin
+	}
+	if callee.Pkg == nil || callee.Pkg.Pkg.Path() != "errors" || callee.Name() != "AsType" {
+		return false
+	}
+	args := call.Call.Args
+	return len(args) > 0 && nilCheckEquivalent(args[0], v)
 }
 
 // isErrorsIsOrAs checks if the call is errors.Is(v, target) or errors.As(v, ...)

--- a/tools/errunchecked/testdata/src/a/a.go
+++ b/tools/errunchecked/testdata/src/a/a.go
@@ -837,3 +837,339 @@ func goodCtxFieldReassignLimitation(ctx1, ctx2 context.Context) error {
 	h.ctx = ctx2
 	return errutil.With(h.ctx.Err())
 }
+
+// isFooErr returns true only for non-nil errors: the nil case returns false
+// before any inspection, so its true branch works as a nil check.
+func isFooErr(err error) bool {
+	if err == nil {
+		return false
+	}
+	return err.Error() == "foo"
+}
+
+// Good: a predicate helper's true branch establishes non-nil.
+func goodPredicateHelper() error {
+	err := returnsErr()
+	if isFooErr(err) {
+		return errutil.With(err)
+	}
+	return nil
+}
+
+// Good: the predicate proves through && short-circuit conditions too.
+func goodPredicateHelperAnd(other bool) error {
+	err := returnsErr()
+	if other && isFooErr(err) {
+		return errutil.With(err)
+	}
+	return nil
+}
+
+// truthy can return true for a nil error, so it proves nothing.
+func truthy(error) bool {
+	return true
+}
+
+// Bad: a predicate without a nil guard does not establish non-nil.
+func badPredicateNoGuard() error {
+	err := returnsErr()
+	if truthy(err) {
+		return errutil.With(err) // want `do not directly wrap`
+	}
+	return nil
+}
+
+// mergedPredicate returns a value merged from guarded and unguarded paths (an
+// SSA phi); the value-level proof accepts it: the unguarded incoming is
+// constant false, and the guarded incoming arrives from the err != nil branch.
+func mergedPredicate(err error, other bool) bool {
+	return err != nil && other
+}
+
+// Good: the merged-value predicate establishes non-nil.
+func goodMergedPredicate() error {
+	err := returnsErr()
+	if mergedPredicate(err, true) {
+		return errutil.With(err)
+	}
+	return nil
+}
+
+// reversedMergedPredicate puts the nil check in the merged value itself rather
+// than the guarding branch.
+func reversedMergedPredicate(err error, other bool) bool {
+	return other && err != nil
+}
+
+// Good: the reversed merged-value predicate establishes non-nil too.
+func goodReversedMergedPredicate() error {
+	err := returnsErr()
+	if reversedMergedPredicate(err, true) {
+		return errutil.With(err)
+	}
+	return nil
+}
+
+// isNamedErr mirrors the comma-ok-and-condition helper shape: true requires
+// ok, and ok (an errors.AsType match) implies a non-nil err — no explicit nil
+// guard needed.
+func isNamedErr(err error, name string) bool {
+	cErr, ok := errors.AsType[*customErr](err)
+	return ok && cErr.Error() == name
+}
+
+// Good: the comma-ok-and-condition predicate establishes non-nil.
+func goodCommaOkPredicate() error {
+	err := returnsErr()
+	if isNamedErr(err, "x") {
+		return errutil.With(err)
+	}
+	return nil
+}
+
+// orPredicate can return true for a nil error (when other is true), so it
+// proves nothing.
+func orPredicate(err error, other bool) bool {
+	return err != nil || other
+}
+
+// Bad: the || merge does not establish non-nil.
+func badOrPredicate() error {
+	err := returnsErr()
+	if orPredicate(err, true) {
+		return errutil.With(err) // want `do not directly wrap`
+	}
+	return nil
+}
+
+// negatedPredicate proves through negation of a recognized condition.
+func negatedPredicate(err error) bool {
+	return !(err == nil)
+}
+
+// Good: the negated predicate establishes non-nil.
+func goodNegatedPredicate() error {
+	err := returnsErr()
+	if negatedPredicate(err) {
+		return errutil.With(err)
+	}
+	return nil
+}
+
+// isSentinelErr forwards to errors.Is with a never-nil package sentinel: the
+// target is provably non-nil, so the predicate is recognized without an
+// explicit nil guard.
+func isSentinelErr(err error) bool {
+	return errors.Is(err, sentinel)
+}
+
+// Good: the sentinel-target predicate establishes non-nil.
+func goodSentinelTargetPredicate() error {
+	err := returnsErr()
+	if isSentinelErr(err) {
+		return errutil.With(err)
+	}
+	return nil
+}
+
+// isSentinelEqual compares against the proven sentinel: equality with a
+// provably non-nil value needs no branch-position trust.
+func isSentinelEqual(err error) bool {
+	return err == sentinel
+}
+
+// Good: equality against a proven sentinel establishes non-nil.
+func goodSentinelEqualPredicate() error {
+	err := returnsErr()
+	if isSentinelEqual(err) {
+		return errutil.With(err)
+	}
+	return nil
+}
+
+// isForwardedTarget forwards its own parameter as the errors.Is target;
+// isForwardedTarget(nil, nil) is true, so it proves nothing.
+func isForwardedTarget(err, target error) bool {
+	return errors.Is(err, target)
+}
+
+// Bad: the forwarded-target predicate is not recognized.
+func badForwardedTargetPredicate() error {
+	err := returnsErr()
+	if isForwardedTarget(err, nil) {
+		return errutil.With(err) // want `do not directly wrap`
+	}
+	return nil
+}
+
+// errMutable is assigned nil outside initialization, so it is not a sentinel.
+var errMutable = errors.New("mutable")
+
+func resetMutable() {
+	errMutable = nil
+}
+
+func isMutableErr(err error) bool {
+	return errors.Is(err, errMutable)
+}
+
+// Bad: a target var with a nil store somewhere is not a sentinel.
+func badMutableTargetPredicate() error {
+	err := returnsErr()
+	resetMutable()
+	if isMutableErr(err) {
+		return errutil.With(err) // want `do not directly wrap`
+	}
+	return nil
+}
+
+// errEscapes has its address passed away, so its stores cannot be tracked.
+var errEscapes = errors.New("escapes")
+
+func escapeVar(p *error) {
+	_ = p
+}
+
+func init() {
+	escapeVar(&errEscapes)
+}
+
+func isEscapedErr(err error) bool {
+	return errors.Is(err, errEscapes)
+}
+
+// Bad: an address-escaping target var is not a sentinel.
+func badEscapedTargetPredicate() error {
+	err := returnsErr()
+	if isEscapedErr(err) {
+		return errutil.With(err) // want `do not directly wrap`
+	}
+	return nil
+}
+
+// sentinelEqualPredicate returns equality against a possibly-nil parameter.
+// Sentinel equality is only trusted in branch position, never as a returned
+// value — errors.Is's own body ends in this shape and must not get a fact.
+func sentinelEqualPredicate(err, target error) bool {
+	return err == target
+}
+
+// Bad: returned sentinel equality proves nothing (true for nil == nil).
+func badSentinelEqualPredicate() error {
+	err := returnsErr()
+	if sentinelEqualPredicate(err, nil) {
+		return errutil.With(err) // want `do not directly wrap`
+	}
+	return nil
+}
+
+// loopPredicate accumulates its result through a loop phi cycle, proved
+// inductively over iterations: res starts false and can only become true via
+// err != nil, with the res-was-already-true edge covered by the induction
+// hypothesis.
+func loopPredicate(err error, n int) bool {
+	res := false
+	for i := 0; i < n; i++ {
+		res = res || err != nil
+	}
+	return res
+}
+
+// Good: the loop-accumulator predicate establishes non-nil.
+func goodLoopPredicate() error {
+	err := returnsErr()
+	if loopPredicate(err, 3) {
+		return errutil.With(err)
+	}
+	return nil
+}
+
+// loopUnrelated can become true from a value unrelated to err, so the
+// induction has no sound base case.
+func loopUnrelated(err error, other bool, n int) bool {
+	res := false
+	for i := 0; i < n; i++ {
+		res = res || other
+	}
+	_ = err
+	return res
+}
+
+// Bad: a loop accumulating an unrelated condition proves nothing.
+func badLoopUnrelatedPredicate() error {
+	err := returnsErr()
+	if loopUnrelated(err, true, 3) {
+		return errutil.With(err) // want `do not directly wrap`
+	}
+	return nil
+}
+
+// loopFlip negates its accumulator each iteration, so the induction
+// hypothesis (stated for true) cannot discharge the flipped edge.
+func loopFlip(err error, n int) bool {
+	res := err != nil
+	for i := 0; i < n; i++ {
+		res = !res
+	}
+	return res
+}
+
+// Bad: a flipping accumulator can be true on iterations where err is nil.
+func badLoopFlipPredicate() error {
+	err := returnsErr()
+	if loopFlip(err, 3) {
+		return errutil.With(err) // want `do not directly wrap`
+	}
+	return nil
+}
+
+// fooChecker.Is shows predicate methods work; the receiver shifts the error to
+// ssa argument 1. Its exported name also gets a fact (Exported is name-based).
+type fooChecker struct{}
+
+func (fooChecker) Is(err error) bool { // want Is:`nonNilWhenTrue\[1\]`
+	if err == nil {
+		return false
+	}
+	return true
+}
+
+// Good: predicate methods establish non-nil like predicate functions.
+func goodPredicateMethod() error {
+	err := returnsErr()
+	var f fooChecker
+	if f.Is(err) {
+		return errutil.With(err)
+	}
+	return nil
+}
+
+// Bad: the predicate guards a different error than the wrapped one.
+func badPredicateDifferentErr() error {
+	err1 := returnsErr()
+	err2 := returnsErr()
+	if isFooErr(err1) {
+		return errutil.With(err2) // want `do not directly wrap`
+	}
+	return nil
+}
+
+// Good: errors.AsType's ok is the generic equivalent of errors.As — a nil
+// error matches no target type.
+func goodErrorsAsTypeCheck() error {
+	err := returnsErr()
+	if _, ok := errors.AsType[*customErr](err); ok {
+		return errutil.With(err)
+	}
+	return nil
+}
+
+// Bad: the AsType ok guards a different error than the wrapped one.
+func badErrorsAsTypeDifferentErr() error {
+	err1 := returnsErr()
+	err2 := returnsErr()
+	if _, ok := errors.AsType[*customErr](err1); ok {
+		return errutil.With(err2) // want `do not directly wrap`
+	}
+	return nil
+}

--- a/tools/errunchecked/testdata/src/b/b.go
+++ b/tools/errunchecked/testdata/src/b/b.go
@@ -4,6 +4,8 @@
 package b
 
 import (
+	"errors"
+
 	"dep"
 
 	"github.com/graxinc/errutil"
@@ -60,4 +62,47 @@ func goodWrapDepNilGuarded() error {
 // Good: facts from generated files still vouch for handwritten callers.
 func goodWrapDepGenerated() error {
 	return errutil.With(dep.GeneratedAlwaysErr())
+}
+
+// Good: dep.IsDep carries a nonNilWhenTrue fact, so its true branch is a nil
+// check even without the body.
+func goodWrapDepPredicate() error {
+	err := dep.MaybeErr(true)
+	if dep.IsDep(err) {
+		return errutil.With(err)
+	}
+	return nil
+}
+
+// Bad: dep.Truthy has no predicate fact.
+func badWrapDepTruthy() error {
+	err := dep.MaybeErr(true)
+	if dep.Truthy(err) {
+		return errutil.With(err) // want `do not directly wrap`
+	}
+	return nil
+}
+
+// Good: merged-condition predicate facts import like any other.
+func goodWrapDepMergedPredicate() error {
+	err := dep.MaybeErr(true)
+	if dep.IsDepMerged(err, true) {
+		return errutil.With(err)
+	}
+	return nil
+}
+
+// isDepTarget forwards to errors.Is with dep's exported sentinel; the
+// nonNilVar fact carries the proof even though dep's body is unavailable.
+func isDepTarget(err error) bool {
+	return errors.Is(err, dep.ErrDep)
+}
+
+// Good: cross-package sentinel facts make the predicate provable.
+func goodWrapDepSentinelPredicate() error {
+	err := dep.MaybeErr(true)
+	if isDepTarget(err) {
+		return errutil.With(err)
+	}
+	return nil
 }

--- a/tools/errunchecked/testdata/src/dep/dep.go
+++ b/tools/errunchecked/testdata/src/dep/dep.go
@@ -67,3 +67,27 @@ func Hidden() hidden { return hidden{} }
 func GenericAlways[T any]() error { // want GenericAlways:`nonNilError\[0\]`
 	return errutil.New(nil)
 }
+
+// IsDep returns true only for non-nil errors, so it carries a predicate fact
+// importing packages can use as a nil check.
+func IsDep(err error) bool { // want IsDep:`nonNilWhenTrue\[0\]`
+	if err == nil {
+		return false
+	}
+	return err.Error() == "dep"
+}
+
+// Truthy can return true for a nil error, so it gets no predicate fact.
+func Truthy(error) bool {
+	return true
+}
+
+// IsDepMerged returns a merged condition; the value-level proof still exports
+// a predicate fact for it.
+func IsDepMerged(err error, other bool) bool { // want IsDepMerged:`nonNilWhenTrue\[0\]`
+	return err != nil && other
+}
+
+// ErrDep is a never-nil sentinel: assigned once at initialization, with a
+// never-escaping address. The fact lets importers prove against it.
+var ErrDep = errutil.New(nil) // want ErrDep:`nonNilVar`

--- a/tools/internal/shared/shared.go
+++ b/tools/internal/shared/shared.go
@@ -252,12 +252,17 @@ func UnderlyingCall(v ssa.Value) (call *ssa.Call, ok bool) {
 
 var errType = types.Universe.Lookup("error").Type()
 
+// IsErrorType reports whether t is the error interface type.
+func IsErrorType(t types.Type) bool {
+	return types.Identical(t, errType)
+}
+
 // ErrorResultIndices returns the indices of all error results in the signature.
 func ErrorResultIndices(sig *types.Signature) []int {
 	results := sig.Results() // nil-safe: (*types.Tuple).Len reports 0 for a nil tuple.
 	var indices []int
 	for i := range results.Len() {
-		if types.Identical(results.At(i).Type(), errType) {
+		if IsErrorType(results.At(i).Type()) {
 			indices = append(indices, i)
 		}
 	}


### PR DESCRIPTION
- Recognize bool helper predicates via nonNilWhenTrue facts
- Recognize errors.AsType comma-ok like errors.As
- Prove merged conditions like `return ok && a.Code == code`
- Prove never-nil sentinel vars, exported as nonNilVar facts
- Prove loop accumulators by induction over iterations
- Restrict sentinel trust to branch position (errors.Is fact regression)

Each of these used to be flagged (or required a `//errutil:unchecked` directive); all are now proven clean:

**1. Predicate helpers — nil-guard form**

```go
func isFooErr(err error) bool {
    if err == nil {
        return false
    }
    return errors.As(err, ...) // any inspection
}

if isFooErr(err) {
    return errutil.Wrap(err) // ok: true implies err non-nil
}
```

Works for methods too (`if c.IsFoo(err)`), and cross-package — the helper carries a `nonNilWhenTrue` fact.

**2. `errors.AsType` comma-ok**

```go
if apiErr, ok := errors.AsType[*APIError](err); ok {
    return errutil.Wrap(err) // ok: a nil error matches no type
}
```

**3. Merged conditions (no explicit guard at all)**

```go
func isCodeErr(err error, code string) bool {
    a, ok := errors.AsType[*APIError](err)
    return ok && a.Code == code // ok: true requires ok, ok implies non-nil
}

func isMerged(err error, other bool) bool {
    return err != nil && other // ok: the unguarded incoming is constant false
}

func isNotNil(err error) bool {
    return !(err == nil) // ok: negation flips the polarity
}
```

**4. Sentinel-target predicates** — proven, not trusted

```go
var errFoo = errors.New("foo") // assigned once, address never escapes

func isFoo(err error) bool {
    return errors.Is(err, errFoo) // ok: errFoo is a proven never-nil sentinel
}

func isEOF(err error) bool {
    return err == io.EOF // ok: cross-package via the nonNilVar fact
}
```

**5. Loop accumulators** — proven by induction over iterations

```go
func anyFailed(err error, n int) bool {
    res := false
    for i := 0; i < n; i++ {
        res = res || err != nil // ok: only path to true is err != nil
    }
    return res
}
```

And the boundaries that stay flagged, deliberately:

```go
func isOneOf(err, target error) bool {
    return errors.Is(err, target) // rejected: isOneOf(nil, nil) is true
}

func looksBad(err error, other bool) bool {
    return err != nil || other // rejected: true with nil err when other is true
}

var errMut = errors.New("x")
func reset() { errMut = nil } // errMut rejected as sentinel: nil store exists
```